### PR TITLE
Change SAML migration scripts to use environment variables for appliance details

### DIFF
--- a/migrate_saml/create_local_user_groups.py
+++ b/migrate_saml/create_local_user_groups.py
@@ -7,12 +7,15 @@
 
 import json
 import requests
+import os
 
-# The IP address or hostname of the ExtraHop system.
-HOST = "https://extrahop.example.com"
-# The API key generated from the ExtraHop system.
-API_KEY = "123456789abcdefghijklmnop"
+# The IP address or hostname of the ExtraHop system. Set via OS env variable.
+# If desired, replace with hardcoded value, e.g. HOST = "https://extrahop.example.com"
+HOST = os.environ['EXTRAHOP_HOST']
 
+# The API key generated from the ExtraHop system. Set via OS env variable.
+# If desired, replace with hardcoded value, e.g. API_KEY = "123456789abcdefghijklmnop"
+API_KEY = os.environ['EXTRAHOP_API_KEY']
 
 USER_MAP_FILE = "user_map.json"
 GROUPS_FILE = "user_groups.json"

--- a/migrate_saml/create_saml_accounts.py
+++ b/migrate_saml/create_saml_accounts.py
@@ -9,11 +9,16 @@ import json
 import requests
 import csv
 import sys
+import os
 
-# The IP address or hostname of the ExtraHop system.
-HOST = "https://extrahop.example.com"
-# The API key generated from the ExtraHop system.
-API_KEY = "123456789abcdefghijklmnop"
+# The IP address or hostname of the ExtraHop system. Set via OS env variable.
+# If desired, replace with hardcoded value, e.g. HOST = "https://extrahop.example.com"
+HOST = os.environ['EXTRAHOP_HOST']
+
+# The API key generated from the ExtraHop system. Set via OS env variable.
+# If desired, replace with hardcoded value, e.g. API_KEY = "123456789abcdefghijklmnop"
+API_KEY = os.environ['EXTRAHOP_API_KEY']
+
 # Determines whether SAML account names are retrieved from a CSV file.
 READ_CSV_FILE = False
 # The name of the CSV file that SAML account names are retrieved from if READ_CSV_FILE is set to True.

--- a/migrate_saml/delete_remote_users.py
+++ b/migrate_saml/delete_remote_users.py
@@ -7,11 +7,15 @@
 
 import json
 import requests
+import os
 
-# The IP address or hostname of the ExtraHop system.
-HOST = "https://extrahop.example.com"
-# The API key generated from the ExtraHop system.
-API_KEY = "123456789abcdefghijklmnop"
+# The IP address or hostname of the ExtraHop system. Set via OS env variable.
+# If desired, replace with hardcoded value, e.g. HOST = "https://extrahop.example.com"
+HOST = os.environ['EXTRAHOP_HOST']
+
+# The API key generated from the ExtraHop system. Set via OS env variable.
+# If desired, replace with hardcoded value, e.g. API_KEY = "123456789abcdefghijklmnop"
+API_KEY = os.environ['EXTRAHOP_API_KEY']
 
 
 USER_MAP_FILE = "user_map.json"

--- a/migrate_saml/retrieve_local_user_groups.py
+++ b/migrate_saml/retrieve_local_user_groups.py
@@ -7,11 +7,15 @@
 
 import json
 import requests
+import os
 
-# The IP address or hostname of the ExtraHop system.
-HOST = "https://extrahop.example.com"
-# The API key generated from the ExtraHop system.
-API_KEY = "123456789abcdefghijklmnop"
+# The IP address or hostname of the ExtraHop system. Set via OS env variable.
+# If desired, replace with hardcoded value, e.g. HOST = "https://extrahop.example.com"
+HOST = os.environ['EXTRAHOP_HOST']
+
+# The API key generated from the ExtraHop system. Set via OS env variable.
+# If desired, replace with hardcoded value, e.g. API_KEY = "123456789abcdefghijklmnop"
+API_KEY = os.environ['EXTRAHOP_API_KEY']
 
 
 OUTPUT_FILE = "user_groups.json"

--- a/migrate_saml/retrieve_remote_users.py
+++ b/migrate_saml/retrieve_remote_users.py
@@ -8,11 +8,15 @@
 import json
 import requests
 import sys
+import os
 
-# The IP address or hostname of the ExtraHop system.
-HOST = "https://extrahop.example.com"
-# The API key generated from the ExtraHop system.
-API_KEY = "123456789abcdefghijklmnop"
+# The IP address or hostname of the ExtraHop system. Set via OS env variable.
+# If desired, replace with hardcoded value, e.g. HOST = "https://extrahop.example.com"
+HOST = os.environ['EXTRAHOP_HOST']
+
+# The API key generated from the ExtraHop system. Set via OS env variable.
+# If desired, replace with hardcoded value, e.g. API_KEY = "123456789abcdefghijklmnop"
+API_KEY = os.environ['EXTRAHOP_API_KEY']
 
 OUTPUT_FILE = "user_map.json"
 headers = {"Authorization": "ExtraHop apikey=%s" % API_KEY}

--- a/migrate_saml/retrieve_sharing.py
+++ b/migrate_saml/retrieve_sharing.py
@@ -7,14 +7,20 @@
 
 import json
 import requests
+import os
 
-# The IP address or hostname of the ExtraHop system.
-HOST = "https://extrahop.example.com"
-# The API key generated from the ExtraHop system.
-API_KEY = "123456789abcdefghijklmnop"
+# The IP address or hostname of the ExtraHop system. Set via OS env variable.
+# If desired, replace with hardcoded value, e.g. HOST = "https://extrahop.example.com"
+HOST = os.environ['EXTRAHOP_HOST']
+
+# The API key generated from the ExtraHop system. Set via OS env variable.
+# If desired, replace with hardcoded value, e.g. API_KEY = "123456789abcdefghijklmnop"
+API_KEY = os.environ['EXTRAHOP_API_KEY']
+
 # The type of customization metadata to retrieve.
 #     The following values are valid: 'dashboards', 'activitymaps'
 OBJECT_TYPE = "dashboards"
+
 # The name of the JSON file to save customization metadata in.
 #     The following values are valid: 'dashboards', 'activitymaps'
 OUTPUT_FILE = "dashboards.json"

--- a/migrate_saml/transfer_sharing.py
+++ b/migrate_saml/transfer_sharing.py
@@ -8,11 +8,16 @@
 import json
 import requests
 import sys
+import os
 
-# The IP address or hostname of the ExtraHop system.
-HOST = "https://extrahop.example.com"
-# The API key generated from the ExtraHop system.
-API_KEY = "ac09e68cf6b5499697fe93d3930e41ed"
+# The IP address or hostname of the ExtraHop system. Set via OS env variable.
+# If desired, replace with hardcoded value, e.g. HOST = "https://extrahop.example.com"
+HOST = os.environ['EXTRAHOP_HOST']
+
+# The API key generated from the ExtraHop system. Set via OS env variable.
+# If desired, replace with hardcoded value, e.g. API_KEY = "123456789abcdefghijklmnop"
+API_KEY = os.environ['EXTRAHOP_API_KEY']
+
 # The type of customization to transfer.
 #     The following values are valid: 'dashboards', 'activitymaps', 'reports'
 OBJECT_TYPE = "dashboards"


### PR DESCRIPTION
This pull request suggests updating the SAML migration scripts to use operating system environment variables for retrieving the ExtraHop appliance's URL and API key instead of requiring administrators to individually modify all 7 Python scripts. Doing it this way provides the following benefits:

- Lowers likelihood of accidentally exposing secrets for admins who store these scripts in source control, multi-user systems or shared file storage
- Makes it easier to remedy any errors in configuration (e.g. an accidental trailing slash in the appliance URL)
- Would condense [ExtraHop SAML migration documentation](https://docs.extrahop.com/8.3/migrate-saml-rest/) to include one first step of asking the administrator to set environment variables once prior to running any of the scripts, instead of duplicating file modification instructions:
```
# Mac/Unix
export EXTRAHOP_HOST=https://extrahop.example.com
export EXTRAHOP_API_KEY=123456789abcdefghijklmnop

# Windows
set EXTRAHOP_HOST=https://extrahop.example.com
set EXTRAHOP_API_KEY=123456789abcdefghijklmnop
```